### PR TITLE
Build libmvas as a shared library and add SONAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,11 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 
 # All Targets and their properties
-add_library(mvas STATIC src/vas.c src/segment.c)
+add_library(mvas SHARED src/vas.c)
 target_include_directories(mvas PUBLIC include)
+
+set_property(TARGET mvas PROPERTY VERSION "0.1")
+set_property(TARGET mvas PROPERTY SOVERSION 1 )
 
 # Installing targets
 install(TARGETS mvas


### PR DESCRIPTION
Changed the static library to dynamic library for packaging reasons.
Additionally it is important to define a version and a SONAME to the library.
This commit basically add SONAME, make the library shared, and removed the
segment part from the final library.